### PR TITLE
properly use the existing dataSource

### DIFF
--- a/metridoc-job-core/src/main/groovy/metridoc/core/services/ConfigService.groovy
+++ b/metridoc-job-core/src/main/groovy/metridoc/core/services/ConfigService.groovy
@@ -129,7 +129,7 @@ class ConfigService extends DefaultService {
         def embeddedDataSource
         try {
             if (binding.hasVariable("args")) {
-                localMysql = binding.args.find { it.contains("-localMysql") }
+                localMysql = binding.args.find { it.contains("-localMysql") || it.contains("-localMySql")}
                 if (localMysql) {
                     def dataSource = DataSourceConfigUtil.localMysqlDataSource
                     binding.dataSource = dataSource

--- a/metridoc-job-core/src/main/groovy/metridoc/core/services/DataSourceService.groovy
+++ b/metridoc-job-core/src/main/groovy/metridoc/core/services/DataSourceService.groovy
@@ -20,6 +20,7 @@ package metridoc.core.services
 import org.hibernate.Session
 import org.hibernate.SessionFactory
 
+import javax.sql.DataSource
 import java.util.concurrent.atomic.AtomicBoolean
 
 /**
@@ -33,7 +34,27 @@ abstract class DataSourceService extends DefaultService {
     String dataSourcePrefix = "dataSource"
     private boolean enableForRan = false
 
+    protected static dataSourceHash = [:]
+
+    static DataSource getDataSoruce(String dataSourceName) {
+        def trimmedName = dataSourceName.trim()
+        assert dataSourceHash[trimmedName] : "dataSource [${trimmedName}] does not exist"
+        dataSourceHash[trimmedName]
+    }
+
     void init() {
+        def dataSourceInBinding = binding.variables.find {String key, value -> key.startsWith("dataSource") &&
+                value instanceof DataSource}
+
+        if(dataSourceInBinding) {
+            binding.variables.each {String key, value ->
+                if(key.startsWith("dataSource") && value instanceof DataSource) {
+                    dataSourceHash[key] = value
+                }
+            }
+            return
+        }
+
         def dataSource = config."$dataSourcePrefix"
         if (embeddedDataSource) {
             dataSource.url = "jdbc:h2:mem:devDb;MVCC=TRUE;LOCK_TIMEOUT=10000"

--- a/metridoc-job-core/src/main/groovy/metridoc/core/services/HibernateService.groovy
+++ b/metridoc-job-core/src/main/groovy/metridoc/core/services/HibernateService.groovy
@@ -64,14 +64,6 @@ class HibernateService extends DataSourceService {
         sessionFactory = createSessionFactory()
     }
 
-    SessionFactory getSessionFactory() {
-        if (sessionFactory) {
-            return sessionFactory
-        }
-
-        sessionFactory = createSessionFactory()
-    }
-
     @SuppressWarnings("GroovyMissingReturnStatement")
     Properties convertDataSourcePropsToHibernate(ConfigObject configObject) {
         DataSourceConfigUtil.getHibernateOnlyProperties(configObject, dataSourcePrefix)

--- a/metridoc-job-core/src/test/groovy/metridoc/core/services/HibernateServiceTest.groovy
+++ b/metridoc-job-core/src/test/groovy/metridoc/core/services/HibernateServiceTest.groovy
@@ -84,8 +84,7 @@ class HibernateServiceTest {
         binding.includeService(ConfigService)
         def service = binding.includeService(HibernateService)
         assert service.localMysql
-        def config = binding.config
-        assert "jdbc:mysql://localhost:3306/test" == config.dataSource.url
+        assert "jdbc:mysql://localhost:3306/test" == binding.dataSource.url
     }
 }
 

--- a/metridoc-tool-gorm/src/main/groovy/metridoc/service/gorm/GormService.groovy
+++ b/metridoc-tool-gorm/src/main/groovy/metridoc/service/gorm/GormService.groovy
@@ -18,6 +18,7 @@
 package metridoc.service.gorm
 
 import groovy.text.XmlTemplateEngine
+import metridoc.core.InjectArg
 import metridoc.core.services.DataSourceService
 import metridoc.iterators.Iterators
 import metridoc.tool.gorm.GormClassLoaderPostProcessor
@@ -36,7 +37,9 @@ import java.text.SimpleDateFormat
  * @author Tommy Barker
  */
 class GormService extends DataSourceService {
+    @InjectArg(ignore = true)
     ApplicationContext applicationContext
+
 
     static {
         Iterators.WRITERS["gorm"] = GormIteratorWriter
@@ -88,7 +91,9 @@ class GormService extends DataSourceService {
         template.make([
                 gormBeans: gormBeans,
                 hibernateProperties: hibernateProperties,
-                dataSourceProperties: dataSourceProperties
+                dataSourceProperties: dataSourceProperties,
+                useFactoryMethod: !dataSourceHash.isEmpty(),
+                dataSourcePrefix: dataSourcePrefix
         ]).writeTo(file.newWriter("utf-8"))
         file.deleteOnExit()
         applicationContext = new FileSystemXmlApplicationContext(file.toURI().toURL().toString())

--- a/metridoc-tool-gorm/src/main/resources/gormToolContext.xml
+++ b/metridoc-tool-gorm/src/main/resources/gormToolContext.xml
@@ -95,9 +95,17 @@
         <constructor-arg index="1" value="#{grailsApplication.config}"/>
     </bean>
 
-    <bean id="dataSource" class="org.apache.commons.dbcp.BasicDataSource">
-        <gsp:scriptlet>dataSourceProperties.each {key, value -></gsp:scriptlet>
-        <property name="${key}" value="${value}"/>
-        <gsp:scriptlet>}</gsp:scriptlet>
-    </bean>
+    <gsp:scriptlet>if(useFactoryMethod) {</gsp:scriptlet>
+        <bean id="dataSource" class="metridoc.service.gorm.GormService" factory-method="getDataSoruce">
+            <constructor-arg>
+                <value>${dataSourcePrefix}</value>
+            </constructor-arg>
+        </bean>
+    <gsp:scriptlet>} else {</gsp:scriptlet>
+        <bean id="dataSource" class="org.apache.commons.dbcp.BasicDataSource">
+            <gsp:scriptlet>dataSourceProperties.each {key, value -></gsp:scriptlet>
+            <property name="${key}" value="${value}"/>
+            <gsp:scriptlet>}</gsp:scriptlet>
+        </bean>
+    <gsp:scriptlet>}</gsp:scriptlet>
 </beans>


### PR DESCRIPTION
Currently gorm is booting while using a spring generated dataSource.
 With this change, a preexisting dataSource will be used instead.

 Issue #61
