### PR TITLE
fix case sensitive columns

### DIFF
--- a/metridoc-job-core/src/test/groovy/metridoc/sql/SqlPlusSpec.groovy
+++ b/metridoc-job-core/src/test/groovy/metridoc/sql/SqlPlusSpec.groovy
@@ -73,4 +73,20 @@ class SqlPlusSpec extends Specification {
         then: "there will be an error"
         thrown SQLException
     }
+
+    void "test bestEffortOrdering"() {
+        given:
+        def record = [
+                bar: 1,
+                FOO: 2,
+                foobar: 3
+        ]
+        def params = ["BAR", "foo", "foobar"] as SortedSet
+
+        when:
+        def recordKeys = SqlPlus.bestEffortOrdering(record, params).keySet() as SortedSet
+
+        then:
+        recordKeys == params
+    }
 }


### PR DESCRIPTION
add best effort ordering of variables where metridoc sql tries to
properly order and match column headers regardless of case.
