### PR TITLE
handle mix cased records

### DIFF
--- a/metridoc-job-core/src/main/groovy/metridoc/sql/InsertableRecord.groovy
+++ b/metridoc-job-core/src/main/groovy/metridoc/sql/InsertableRecord.groovy
@@ -1,5 +1,6 @@
 package metridoc.sql
 
+import groovy.sql.GroovyRowResult
 import groovy.util.logging.Slf4j
 
 import java.sql.SQLException
@@ -15,7 +16,7 @@ class InsertableRecord {
     @Lazy(soft = true)
     LinkedHashMap<String, Object> transformedRecord = {
         LinkedHashMap response = [:]
-        def record = originalRecord.clone() as Map
+        Map record = new GroovyRowResult(originalRecord.clone())
         insertMetaData.sortedParams.each { String paramName ->
             if (!record.containsKey(paramName)) {
                 if (record.containsKey(paramName.toUpperCase())) {

--- a/metridoc-job-core/src/test/groovy/metridoc/sql/InsertableRecordSpec.groovy
+++ b/metridoc-job-core/src/test/groovy/metridoc/sql/InsertableRecordSpec.groovy
@@ -11,14 +11,14 @@ class InsertableRecordSpec extends Specification {
         given:
         def metaData = new InsertMetaData(
                 sortedParams: [
-                        "foo", "BAR", "baz"
+                        "foo_bar", "BAR", "baz"
                 ] as SortedSet<String> ,
                 columnsWithDefaults: []
         )
 
         def insertableRecordParams = [
                 originalRecord: [
-                        foo: "bar",
+                        FOO_bar: "bar",
                         bar: "foo"
                 ],
                 insertMetaData: metaData,
@@ -28,7 +28,7 @@ class InsertableRecordSpec extends Specification {
         def transformed = createInsertableRecord(insertableRecordParams).transformedRecord
 
         then:
-        [foo: "bar", BAR: "foo", baz: null] == transformed
+        [foo_bar: "bar", BAR: "foo", baz: null] == transformed
 
         when: "insert has columns with default records"
         def insert = createInsertableRecord(insertableRecordParams)
@@ -37,7 +37,7 @@ class InsertableRecordSpec extends Specification {
         transformed = insert.transformedRecord
 
         then: "the transformed record does not have them IF they are not in original record"
-        [foo: "bar", BAR: "foo"] == transformed
+        [foo_bar: "bar", BAR: "foo"] == transformed
     }
 
     InsertableRecord createInsertableRecord(LinkedHashMap params) {


### PR DESCRIPTION
if a record is mixed case then transforming the record didn't always
work correctly.  Records are now wrapped in a GroovyRowResult which
is a case insensitive Map.
