### PR TITLE
fix import jobs bug

### DIFF
--- a/metridoc-job-cli/src/main/groovy/metridoc/cli/InstallJobCommand.groovy
+++ b/metridoc-job-cli/src/main/groovy/metridoc/cli/InstallJobCommand.groovy
@@ -128,7 +128,7 @@ class InstallJobCommand implements Command {
         }
 
         ArchiveMethods.unzip(destination, jobPathDir, optionSubDirectory)
-        importJobs(jobPathDir, destination)
+        importJobs(jobPathDir, destination, optionSubDirectory)
         def filesToDelete = []
 
         jobPathDir.eachFile {
@@ -158,8 +158,8 @@ class InstallJobCommand implements Command {
         }
     }
 
-    void importJobs(File jobPath, File zipFile) {
-        File directoryOfZipFile = ArchiveMethods.convertZipNameToDirectory(jobPath, zipFile)
+    void importJobs(File jobPath, File zipFile, String subPath) {
+        File directoryOfZipFile = ArchiveMethods.convertZipNameToDirectory(jobPath, zipFile, subPath)
         ImportJobsCommand.addImports(directoryOfZipFile)
     }
 

--- a/metridoc-job-cli/src/main/groovy/metridoc/utils/ArchiveMethods.groovy
+++ b/metridoc-job-cli/src/main/groovy/metridoc/utils/ArchiveMethods.groovy
@@ -144,15 +144,27 @@ class ArchiveMethods {
     }
 
     static File convertZipNameToDirectory(File parent, File zipFile) {
-        def zipName = zipFile.name
-        def directoryName = zipName
+        convertZipNameToDirectory(parent, zipFile, null)
+    }
 
-        if(zipName.endsWith(".zip")) {
-            def index = zipName.lastIndexOf(".zip")
-            directoryName = zipName.substring(0, index)
+    static File convertZipNameToDirectory(File parent, File zipFile, String subPath) {
+        def directory
+        if(subPath) {
+            directory = new File(parent, subPath)
+        }
+        else {
+            def zipName = zipFile.name
+            def directoryName = zipName
+
+            if(zipName.endsWith(".zip")) {
+                def index = zipName.lastIndexOf(".zip")
+                directoryName = zipName.substring(0, index)
+            }
+
+
+            directory = new File(parent, directoryName)
         }
 
-        def directory = new File(parent, directoryName)
         if (!directory.exists()) {
             assert directory.mkdir() : "Could not create directory [$directory]"
         }

--- a/metridoc-job-cli/src/test/groovy/metridoc/cli/InstallJobCommandSpec.groovy
+++ b/metridoc-job-cli/src/test/groovy/metridoc/cli/InstallJobCommandSpec.groovy
@@ -91,6 +91,7 @@ class InstallJobCommandSpec extends Specification {
         then:
         noExceptionThrown()
         new File(temporaryFolder.root, "metridoc-job-gorm").exists()
+        1 == temporaryFolder.root.listFiles().size()
 
         when:
         main = new MetridocMain(
@@ -125,5 +126,4 @@ class InstallJobCommandSpec extends Specification {
         def error = thrown(AssertionError)
         error.message.contains("[garbage] does not exist")
     }
-
 }

--- a/metridoc-job-cli/src/test/groovy/metridoc/utils/ArchiveMethodsSpec.groovy
+++ b/metridoc-job-cli/src/test/groovy/metridoc/utils/ArchiveMethodsSpec.groovy
@@ -13,14 +13,27 @@ class ArchiveMethodsSpec extends Specification {
     TemporaryFolder temporaryFolder = new TemporaryFolder()
 
     void "test converting zip name to directory file"() {
+
         given:
         def parent = temporaryFolder.newFolder("foo")
-
         when:
         def file = ArchiveMethods.convertZipNameToDirectory(parent, new File("metridoc-job-bar-v0.1.zip"))
 
         then:
         "metridoc-job-bar-v0.1" == file.name
+        file.isDirectory()
+        file.parentFile == parent
+    }
+
+    void "test dealing with optional paths"() {
+        given:
+        def parent = temporaryFolder.newFolder("foo")
+
+        when:
+        def file = ArchiveMethods.convertZipNameToDirectory(parent, new File("metridoc-job-bar-v0.1.zip"), "foobar")
+
+        then:
+        "foobar" == file.name
         file.isDirectory()
         file.parentFile == parent
     }


### PR DESCRIPTION
when an optional subdirectory is provided, the import jobs command
was not working properly.  It would try to import jobs according to
the zip file instead of a sub directory of the zip file.  In the
process of doing this it would also create another directory for a
job with nothing in it.
