### PR TITLE
fix id generation

### DIFF
--- a/metridoc-job-bd/src/main/groovy/metridoc/bd/entities/BaseExceptionCode.groovy
+++ b/metridoc-job-bd/src/main/groovy/metridoc/bd/entities/BaseExceptionCode.groovy
@@ -13,7 +13,7 @@ abstract class BaseExceptionCode {
     }
 
     static mapping = {
-        id name: "exceptionCode"
+        id name: "exceptionCode", generator: "assigned"
         version defaultValue: '0'
     }
 }

--- a/metridoc-job-bd/src/main/groovy/metridoc/bd/entities/BaseMinShipDate.groovy
+++ b/metridoc-job-bd/src/main/groovy/metridoc/bd/entities/BaseMinShipDate.groovy
@@ -12,7 +12,7 @@ abstract class BaseMinShipDate {
     }
 
     static mapping = {
-        id name: "requestNumber"
+        id name: "requestNumber", generator: "assigned"
         version(false)
     }
 }

--- a/metridoc-job-bd/src/main/groovy/metridoc/bd/entities/BasePatronType.groovy
+++ b/metridoc-job-bd/src/main/groovy/metridoc/bd/entities/BasePatronType.groovy
@@ -13,7 +13,7 @@ abstract class BasePatronType {
     }
 
     static mapping = {
-        id name: "patronType"
+        id name: "patronType", generator: "assigned"
         version(false)
     }
 }


### PR DESCRIPTION
Some tables use assigned columns for primary keys.  Gorm got confused
 trying to treat them as auto increment columns and refused to create
  the tables properly.
