### PR TITLE
fix IllTracking turnarounds

### DIFF
--- a/metridoc-job-illiad/src/main/groovy/metridoc/illiad/entities/IllTracking.groovy
+++ b/metridoc-job-illiad/src/main/groovy/metridoc/illiad/entities/IllTracking.groovy
@@ -17,6 +17,7 @@ package metridoc.illiad.entities
 
 import grails.persistence.Entity
 import metridoc.illiad.DateUtil
+import org.hibernate.Session
 import org.slf4j.LoggerFactory
 
 /**
@@ -93,8 +94,8 @@ class IllTracking {
                             illTracking.save(failOnError: true)
                         }
                     }
-                }
-                else {
+
+                } else {
                     notDone = false
                 }
             }


### PR DESCRIPTION
For some reason when mixing raw sql and gorm one may need to create
new sessions.  I am baffled trying to figure out why,
but this pull request does seem to work properly.  This is a good
reason to maybe pursue newer grails versions which have GORM outside
of grails available out of the box.
